### PR TITLE
Fix CVE-2021-3520 affected components Lz4 1.9.3 in p7zip17

### DIFF
--- a/C/lz4/lz4.c
+++ b/C/lz4/lz4.c
@@ -1749,7 +1749,7 @@ LZ4_decompress_generic(
                  const size_t dictSize         /* note : = 0 if noDict */
                  )
 {
-    if (src == NULL) { return -1; }
+    if ((src == NULL) || (outputSize < 0)) { return -1; }
 
     {   const BYTE* ip = (const BYTE*) src;
         const BYTE* const iend = ip + srcSize;


### PR DESCRIPTION
Fix CVE-2021-3520 affected components Lz4 1.9.3 in p7zip17